### PR TITLE
Fix some minor stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ erl_crash.dump
 log
 logs
 rel/example_project
+rebar.lock

--- a/src/rebar3_codecov.erl
+++ b/src/rebar3_codecov.erl
@@ -1,6 +1,7 @@
 -module(rebar3_codecov).
 
 -export([init/1]).
+-ignore_xref([init/1]).
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->

--- a/src/rebar3_codecov_prv.erl
+++ b/src/rebar3_codecov_prv.erl
@@ -1,5 +1,4 @@
 -module(rebar3_codecov_prv).
--behaviour(provider).
 
 %% API
 -export([init/1, do/1, format_error/1]).

--- a/src/rebar3_codecov_prv.erl
+++ b/src/rebar3_codecov_prv.erl
@@ -2,6 +2,7 @@
 
 %% API
 -export([init/1, do/1, format_error/1]).
+-ignore_xref([do/1, format_error/1]).
 
 -define(NAMESPACE, codecov).
 -define(PROVIDER, analyze).


### PR DESCRIPTION
These changes address compile-time, `xref` and `dialyzer` warnings for OTP 18.3 - OTP 22.2.